### PR TITLE
Added optional argument to define number of lines of context to show

### DIFF
--- a/git-xltrail-diff.py
+++ b/git-xltrail-diff.py
@@ -33,11 +33,16 @@ def get_vba(workbook):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 8:
+    if not 8 <= len(sys.argv) <= 9:
         print('Unexpected number of arguments')
         sys.exit(0)
 
-    _, workbook_name, workbook_b, _, _, workbook_a, _ , _ = sys.argv
+    if len(sys.argv) == 8:
+        _, workbook_name, workbook_b, _, _, workbook_a, _ , _ = sys.argv
+        numlines = 3
+    if len(sys.argv) == 9:
+        _, numlines, workbook_name, workbook_b, _, _, workbook_a, _, _ = sys.argv
+        numlines = int(numlines)
 
     path_workbook_a = os.path.abspath(workbook_a)
     path_workbook_b = os.path.abspath(workbook_b)
@@ -57,7 +62,7 @@ if __name__ == '__main__':
             diffs.append({
                 'a': '--- a/' + workbook_name + '/VBA/' + module_a,
                 'b': '+++ b/' + workbook_name + '/VBA/' + module_a,
-                'diff': '\n'.join([(Fore.RED if line.startswith('-') else (Fore.GREEN if line.startswith('+') else (Fore.CYAN if line.startswith('@') else ''))) + line.strip('\n') for line in list(unified_diff(workbook_b_modules[module_a].split('\n'), vba_a.split('\n')))[2:]])
+                'diff': '\n'.join([(Fore.RED if line.startswith('-') else (Fore.GREEN if line.startswith('+') else (Fore.CYAN if line.startswith('@') else ''))) + line.strip('\n') for line in list(unified_diff(workbook_b_modules[module_a].split('\n'), vba_a.split('\n'), n=numlines))[2:]])
             })
 
     for module_b, vba_b in workbook_b_modules.items():


### PR DESCRIPTION
This allows the user to define a number of lines in their .gitconfig that they wish to have as context in their merge. For example this allows the .gitconfig to go from this:

```
[diff "xltrail"]
      command = git-xltrail-diff.exe
```

To this:
```
[diff "xltrail"]
      command = git-xltrail-diff.exe 8
```

Default lines of context is 3 and is an optional parameter in difflib(n=3). 